### PR TITLE
Update pif.gov.tf

### DIFF
--- a/terraform/pif.gov.tf
+++ b/terraform/pif.gov.tf
@@ -107,14 +107,6 @@ resource "aws_route53_record" "proposal_txt" {
   records = ["1dHcUZofJi9on3jRwR4I0o-2fGKbMV0OtmF140lvKmU"]
 }
 
-resource "aws_route53_record" "fellows_in_innovation_pif_cname" {
-  zone_id = "${aws_route53_zone.pif_toplevel.zone_id}"
-  name    = "fellows-in-innovation.pif.gov."
-  type    = "CNAME"
-  ttl     = 300
-  records = ["d3at1jdwnpqw7w.cloudfront.net"]
-}
-
 resource "aws_route53_record" "paygap_pif_cname" {
   zone_id = "${aws_route53_zone.pif_toplevel.zone_id}"
   name    = "paygap.pif.gov."


### PR DESCRIPTION
Remove fellows-in-innovation.gov - not an approved public website and not longer maintained